### PR TITLE
Update version of Node & Chrome used in Cypress image

### DIFF
--- a/Dockerfile.cypress
+++ b/Dockerfile.cypress
@@ -1,4 +1,4 @@
-FROM cypress/browsers:node10.16.0-chrome77@sha256:df704dfda7c6e453e78f2f075a9a6a23c428f97dd1b5d09b015adcd05079eca1
+FROM cypress/browsers:node14.16.0-chrome89-ff86
 WORKDIR /app
 
 COPY package.json yarn.lock ./


### PR DESCRIPTION
They don't have an image for Node 15 yet, but it's still worth
getting it closer to what we're actually running in production.