### PR TITLE
Use env var to define the API host

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -3,13 +3,7 @@ import { ApolloProvider, ApolloClient, InMemoryCache } from "@apollo/client";
 
 import Layout from "../components/Layout";
 
-const defineHost = () => {
-  if (process.env.NODE_ENV === "production") return "206.189.38.8";
-
-  return "localhost:8000";
-};
-
-const host = defineHost();
+const host = process.env.API_HOST || "localhost:8000";
 const client = new ApolloClient({
   uri: `http://${host}/graphql`,
   cache: new InMemoryCache({


### PR DESCRIPTION
This is a bit more flexible than basing it on the environment
and hard-coding the IP/domain.